### PR TITLE
Unpin package dependency and separate from development dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,3 @@ flake8==3.5.0
 Sphinx==1.7.5
 cryptography==2.2.2
 PyYAML==4.1
-
-click==6.7
-
-beautifulsoup4==4.6.0
-requests==2.19.1
-diskcache==3.0.6
-selenium==3.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,3 @@ flake8==3.5.0
 Sphinx==1.7.5
 cryptography==2.2.2
 PyYAML==3.13
-
-click==6.7
-
-beautifulsoup4==4.6.0
-requests==2.19.1
-diskcache==3.0.6
-selenium==3.13.0

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,13 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-with open('requirements.txt') as req_file:
-    required = req_file.read().splitlines()
-
-requirements = required
+requirements = [
+    "click>=6.7",
+    "beautifulsoup4>=4.6.0",
+    "requests>=2.19.1",
+    "diskcache>=3.0.6",
+    "selenium>=3.13.0",
+]
 
 setup_requirements = [
     # TODO(yonkornilov): put setup requirements (distutils extensions, etc.) here


### PR DESCRIPTION
See https://github.com/yonkornilov/opus-api/issues/64

This will also help with any app/library depending on this getting a message from GitHub about using an insecure version of the Cryptography package.