### PR TITLE
downgrade pyyaml to 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ tox==3.0.0
 flake8==3.5.0
 Sphinx==1.7.5
 cryptography==2.2.2
-PyYAML==4.1
+PyYAML==3.13
 
 click==6.7
 


### PR DESCRIPTION
This is meant to fix #66 since https://travis-ci.org/yonkornilov/opus-api/jobs/411817193#L491 indicates PyYaml 4.1 is not (or no longer) on PyPi